### PR TITLE
Schema update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ vars:
     zendesk_database: your_database_name
 ```
 
-### Schema Changes
-By default this package will write to a schema titled (target.schema + `_zendesk_staging` within your target database. If this is not where you would like you Zendesk Support staging data to be written to, add the following configuration to your `dbt_project.yml` file:
+### Changing the Build Schema
+By default this package will build the Zendesk Support staging models within a schema titled (<target_schema> + `_zendesk_staging`) in your target database. If this is not where you would like you Zendesk Support staging data to be written to, add the following configuration to your `dbt_project.yml` file:
 
 ```yml
 # dbt_project.yml

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ vars:
     zendesk_database: your_database_name
 ```
 
+Additionally, by default this package will write to a schema titled (target.schema + `_zendesk_staging` within your target database. If this is not where you would like you Zendesk Support staging data to be written to, add the following configuration to your `dbt_project.yml` file:
+
+```yml
+# dbt_project.yml
+
+...
+config-version: 2
+
+models:
+    zendesk_source:
+        +schema: my_new_schema_name
+```
+
 ### Disabling Models
 This package takes into consideration that not every Zendesk account utilizes the `schedule`, `domain_name`, `user_tag`, `organization_tag`, or `ticket_form_history` features, and allows you to disable the corresponding functionality. By default, all variables' values are assumed to be `true`. Add variables for only the tables you want to disable:
 ```yml

--- a/README.md
+++ b/README.md
@@ -32,14 +32,13 @@ vars:
     zendesk_database: your_database_name
 ```
 
-Additionally, by default this package will write to a schema titled (target.schema + `_zendesk_staging` within your target database. If this is not where you would like you Zendesk Support staging data to be written to, add the following configuration to your `dbt_project.yml` file:
+### Schema Changes
+By default this package will write to a schema titled (target.schema + `_zendesk_staging` within your target database. If this is not where you would like you Zendesk Support staging data to be written to, add the following configuration to your `dbt_project.yml` file:
 
 ```yml
 # dbt_project.yml
 
 ...
-config-version: 2
-
 models:
     zendesk_source:
         +schema: my_new_schema_name

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,13 +1,14 @@
 config-version: 2
 
 name: 'zendesk_source'
-version: '0.2.0'
+version: '0.3.0'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 
 models:
   zendesk_source:
     materialized: table
+    +schema: zendesk_staging
     tmp:
       materialized: view
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'zendesk_source_integration_tests'
-version: '0.2.0'
+version: '0.3.0'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 profile: 'integration_tests'


### PR DESCRIPTION
This PR includes the following changes:
- Specifying the build schema to: <target_schema> + `_zendesk_staging`.
         - Note: dbt will append the `_` between the target and custom schema.
- Addition of the `Changing the Build Schema` section within the ReadMe.
- Upgrade the package version from v0.2.0 -> v0.3.0 as this includes a breaking change.