### PR TITLE
Feature: add deleted groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt_zendesk_source v0.8.2
+## Bug Fixes
+- Enable historical modeling: updated the `stg_zendesk__group` model to keep deleted groups. Added `is_deleted` tag to enable filtering in downstream models.
+## Contributors
+- [Estelle Wolski](https://github.com/EstelleBarnoud) ([#36](https://github.com/fivetran/dbt_zendesk_source/pull/36))
+
 # dbt_zendesk_source v0.8.1
 ## Bug Fixes
 - Updated the dbt-utils dispatch within the `stg_zendesk__ticket_schedule_tmp` model to properly dispatch `dbt` as opposed to `dbt_utils` for the cross-db-macros. ([#32](https://github.com/fivetran/dbt_zendesk_source/pull/32))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 config-version: 2
 name: 'zendesk_source'
-version: '0.8.1'
+version: '0.8.2'
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 models:
   zendesk_source:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'zendesk_source_integration_tests'
-version: '0.8.1'
+version: '0.8.2'
 
 profile: 'integration_tests'
 

--- a/models/stg_zendesk__group.sql
+++ b/models/stg_zendesk__group.sql
@@ -29,10 +29,10 @@ final as (
     
     select 
         id as group_id,
-        name
+        name,
+        _fivetran_deleted as is_deleted
     from fields
     
-    where not coalesce(_fivetran_deleted, false)
 )
 
 select * 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Yes, part of dbt Labs internal analytics team!

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
Enable historical modeling: updated the `stg_zendesk__group` model to keep deleted groups. Added `is_deleted` tag to enable filtering in downstream models.

**Use case**: building a historical model of each ticket states at each field update. Would need to override the package model to get group name for historical tickets with deleted groups:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/28601386/233435457-49ca4fb4-f18b-4434-bff1-c34c1afb16ed.png">

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

The `stg_zendesk__group` is a usually small table and is only ever used to join in group names to other downstream models in the `fivetran/zendesk` package. This means models will only be enriched better downstream for historical tickets.

Note: the `is_deleted` tag can be used by teams to filter out outdated records in models outside of these packages, but leaving as is is non breaking.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes, Issue/Feature [link bug/feature number here]
- [x] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] Buildkite). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Buildkite <!--- Buildkite testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)
Installed `fivetran/zendesk` package (team is only using `fivetran/zendesk_source`) & build all package models:
```
dbt build -s zendesk_source zendesk
```
Results:
<img width="392" alt="Screen Shot 2023-04-20 at 12 06 11 PM" src="https://user-images.githubusercontent.com/28601386/233433764-4094cd67-4a33-4404-9103-b41ef53af6c0.png">

Validation on project: test is now passing
<img width="685" alt="image" src="https://user-images.githubusercontent.com/28601386/233436096-2163281e-37db-4e9d-a42d-a6088184a12d.png">


**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
☀️ 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
